### PR TITLE
Remove Web Search Engine dangling hashlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ This repository is a compilation of well-written, step-by-step guides for re-cre
 * [Text Editor](#build-your-own-text-editor)
 * [Visual Recognition System](#build-your-own-visual-recognition-system)
 * [Voxel Engine](#build-your-own-voxel-engine)
-* [Web Search Engine](#build-your-own-web-search-engine)
 * [Web Server](#build-your-own-web-server)
 * [Uncategorized](#uncategorized)
 


### PR DESCRIPTION
Was exploring the repo and clicked on this dead Markdown link
This removes the link. Looks like it wasn't dangling for long
Section removed in the recent https://github.com/codecrafters-io/build-your-own-x/pull/737

