### PR TITLE
change 'How to write an emulator (CHIP-8 interpreter)' tutorial to an archived version

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ It's a great way to learn.
 * [**C**: _Virtual machine in C_](http://web.archive.org/web/20200121100942/https://blog.felixangell.com/virtual-machine-in-c/)
 * [**C**: _Write your Own Virtual Machine_](https://justinmeiners.github.io/lc3-vm/)
 * [**C**: _Writing a Game Boy emulator, Cinoop_](https://cturt.github.io/cinoop.html)
-* [**C++**: _How to write an emulator (CHIP-8 interpreter)_](http://www.multigesture.net/articles/how-to-write-an-emulator-chip-8-interpreter/)
+* [**C++**: _How to write an emulator (CHIP-8 interpreter)_](https://archive.ph/lRWUL)
 * [**C++**: _Emulation tutorial (CHIP-8 interpreter)_](http://www.codeslinger.co.uk/pages/projects/chip8.html)
 * [**C++**: _Emulation tutorial (GameBoy emulator)_](http://www.codeslinger.co.uk/pages/projects/gameboy.html)
 * [**C++**: _Emulation tutorial (Master System emulator)_](http://www.codeslinger.co.uk/pages/projects/mastersystem/memory.html)


### PR DESCRIPTION
The current "How to write an emulator (CHIP-8 interpreter)" tutorial leads to a dead link. There is an archived snapshot on archive.is that I replaced the current URL with in the README. 