### PR TITLE
Replace outdated tutorial link for Python Twitter bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ It's a great way to learn.
 * [**Python**: _Build a Reddit Bot_](http://pythonforengineers.com/build-a-reddit-bot-part-1/)
 * [**Python**: _How To Make A Reddit Bot_](https://www.youtube.com/watch?v=krTUf7BpTc0) [video]
 * [**Python**: _How To Create a Telegram Bot Using Python_](https://khashtamov.com/en/how-to-create-a-telegram-bot-using-python/)
-* [**Python**: _Create a Twitter Bot in Python Using Tweepy_](https://medium.freecodecamp.org/creating-a-twitter-bot-in-python-with-tweepy-ac524157a607)
+* [**Python**: _Create a Twitter Bot in Python Using Tweepy_](https://dev.to/twitterdev/a-comprehensive-guide-for-using-the-twitter-api-v2-using-tweepy-in-python-15d9)
 * [**Python**: _Creating Reddit Bot with Python & PRAW_](https://www.youtube.com/playlist?list=PLIFBTFgFpoJ9vmYYlfxRFV6U_XhG-4fpP) [video]
 * [**R**: _Build A Cryptocurrency Trading Bot with R_](https://towardsdatascience.com/build-a-cryptocurrency-trading-bot-with-r-1445c429e1b1)
 * [**Rust**: _A bot for Starcraft in Rust, C or any other language_](https://habr.com/en/post/436254/)


### PR DESCRIPTION
Twitter has already moved on to its V2 API which breaks any code written before the version update.

The previous tutorial that dates back to 2018 no longer holds any status with the current API.

I have provided an updated tutorial from 2021 on building a Twitter bot using the newest API which is what bot developers should take a look at instead.

If someone finds an even more updated and comprehensive tutorial, let me know 🙂