### PR TITLE
add creating WebSocket server from scratch, using only the RFC doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ It's a great way to learn.
 * [**Python**: _Building a basic HTTP Server from scratch in Python_](http://joaoventura.net/blog/2017/python-webserver/)
 * [**Python**: _Implementing a RESTful Web API with Python & Flask_](http://blog.luisrei.com/articles/flaskrest.html)
 * [**Ruby**: _Building a simple websockets server from scratch in Ruby_](http://blog.honeybadger.io/building-a-simple-websockets-server-from-scratch-in-ruby/)
+* [**JavaScript**: _Building a WebSocket server from scratch, using only the RFC document_]https://medium.com/@ahanshankar/creating-a-websocket-server-using-only-the-rfc-doc-part-1-handshakes-6cbbe16552e5)
 
 #### Uncategorized
 


### PR DESCRIPTION
Adding building  WebSocket server from scratch, using only the RFC documents. I know that there is already a WebSocket tutorial, but this adds value for the following reasons:

1. Its in JS, while the existing tutorial is in Ruby
2. Follows the RFC doc much more closely, providing references
3. A lot more elaborate, with diagrams and references
4. Supports closing hanshakes, ping and pong frames, which the current tutorial does not