### PR TITLE
Removed "Java: Java Voxel Engine Tutorial [video]" as it is not available anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,6 @@ It's a great way to learn.
 #### Build your own `Voxel Engine`
 
 * [**C++**: _Let's Make a Voxel Engine_](https://sites.google.com/site/letsmakeavoxelengine/home)
-* [**Java**: _Java Voxel Engine Tutorial_](https://www.youtube.com/watch?v=QZ4Vk2PkPZk&list=PL80Zqpd23vJfyWQi-8FKDbeO_ZQamLKJL) [video]
 
 #### Build your own `Web Browser`
 


### PR DESCRIPTION
In the Voxel Engine section I removed "Java: Java Voxel Engine Tutorial [video]" as the [video it points to](https://www.youtube.com/watch?v=QZ4Vk2PkPZk&list=PL80Zqpd23vJfyWQi-8FKDbeO_ZQamLKJL) is not (at least publically) available.